### PR TITLE
Bug 1331672 - Change CSS rule to target exit button using id selector.

### DIFF
--- a/browser/themes/shared/fullscreen/warning.inc.css
+++ b/browser/themes/shared/fullscreen/warning.inc.css
@@ -41,7 +41,7 @@ html|*.pointerlockfswarning-domain {
   margin: 0;
 }
 
-html|*.pointerlockfswarning-exit-button {
+html|*#fullscreen-exit-button {
   padding: 5px 30px;
   font: message-box;
   font-size: 14px;


### PR DESCRIPTION
Currently the CSS rule for the fullscreen warning button uses a class selector. However, the button does not have the class and so it is not being targeted by this CSS rule. As a result none of the button's CSS declarations are being applied.